### PR TITLE
Fix missing direnv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
               flake-checker.enable = true;
             };
             packages = [
+              pkgs.direnv
               pkgs.gh
               pkgs.sapling
             ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #42

