### PR TITLE
Fix missing target branch inputs on backport

### DIFF
--- a/command/backport/action.yaml
+++ b/command/backport/action.yaml
@@ -58,4 +58,5 @@ runs:
         pull-request-url: ${{ inputs.pull-request-url }}
         registry: ${{ inputs.registry }}
         sign-commits: ${{ inputs.sign-commits }}
+        target-branch: ${{ steps.command.outputs.params }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #134

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ifba6581163b46992aef5de2ef8e1a4d56a6a6964