### PR TITLE
Fix cache version warning

### DIFF
--- a/direnv/action.yaml
+++ b/direnv/action.yaml
@@ -20,7 +20,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           ${{ inputs.path }}/.direnv


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #200

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I56c3a23189ea016cd8b6a63680574aef6a6a6964