### PR TITLE
Fix path validation on Nix store

### DIFF
--- a/nix/integration/action.yaml
+++ b/nix/integration/action.yaml
@@ -117,6 +117,7 @@ runs:
       run: |
         CONTAINER_REF="$INPUT_CONTAINER_REGISTRY/$INPUT_REPO/$INPUT_TARGET_NAME:$INPUT_CONTAINER_TAG"
         nix run "$INPUT_REGISTRY#oras" -- push "$CONTAINER_REF" \
+          --disable-path-validation \
           --artifact-type application/vnd.shikanime-studio.nixos.images.v1 \
           "$INPUT_PATHS:application/vnd.shikanime-studio.nixos.images.layer.v1+tar"
       shell: bash


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #211

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I11b59ea03c3ce2e99443bf94e18f3d496a6a6964