### PR TITLE
fix: correct skaffold step id, standardize GH_TOKEN, remove unsupported input

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: shikanime-studio/actions/cleanup@v9
         with:
           github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
-          pull-request-url: ${{ github.event.pull_request.html_url }}
 name: Cleanup
 'on':
   pull_request:

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ jobs:
           github_access_token: >-
             ${{ steps.createGithubAppToken.outputs.token
                 || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/update@v7
+      - uses: shikanime-studio/actions/update@v9
         with:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -395,5 +395,5 @@ jobs:
           token: >-
             ${{ steps.createGithubAppToken.outputs.token
                 || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/cleanup@v7
+      - uses: shikanime-studio/actions/cleanup@v9
 ```

--- a/skaffold/integration/action.yaml
+++ b/skaffold/integration/action.yaml
@@ -15,20 +15,21 @@ outputs:
 runs:
   using: composite
   steps:
-    - env:
+    - id: platform
+      env:
         INPUT_PLATFORMS: ${{ inputs.platforms }}
       run: |
         SKAFFOLD_PLATFORM="$(printf '%s' "$INPUT_PLATFORMS" | jq -r 'join(",")')"
         echo "platform=$SKAFFOLD_PLATFORM" >> "$GITHUB_OUTPUT"
       shell: bash
     - env:
-        SKAFFOLD_PLATFORM: ${{ steps.skaffold.outputs.platform }}
+        SKAFFOLD_PLATFORM: ${{ steps.platform.outputs.platform }}
         SKAFFOLD_PROFILE: ${{ inputs.profile }}
       id: skaffold
       run: |
         skaffold config set --global collect-metrics false
-        skaffold build "${args[@]}"
-        MANIFEST="$(skaffold render "${args[@]}")"
+        skaffold build
+        MANIFEST="$(skaffold render)"
         {
           echo 'manifest<<EOF'
           echo "$MANIFEST"

--- a/update/action.yaml
+++ b/update/action.yaml
@@ -46,7 +46,7 @@ runs:
       run: nix run "$INPUT_REGISTRY#ghstack" -- submit
       shell: bash
     - env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
         INPUT_REGISTRY: ${{ inputs.registry }}
       if: inputs.method == 'sapling-pull-request'
       run: nix run "$INPUT_REGISTRY#sapling" -- pr submit


### PR DESCRIPTION
## Summary
- **skaffold/integration**: Add missing `id: platform` to the GITHUB_OUTPUT step so `steps.skaffold.outputs.platform` resolves correctly; remove undefined `${args[@]}` from skaffold build/render calls
- **update/action**: Rename `GITHUB_TOKEN` → `GH_TOKEN` for consistency with all other actions
- **cleanup workflow**: Remove unsupported `pull-request-url` input (cleanup action only accepts `github-token` and `head-ref`)
- **README**: Update `@v7` → `@v9` references for cleanup and update actions