### PR TITLE
Fix skaffold step id and undefined args

### DIFF
--- a/skaffold/integration/action.yaml
+++ b/skaffold/integration/action.yaml
@@ -15,20 +15,21 @@ outputs:
 runs:
   using: composite
   steps:
-    - env:
+    - id: platform
+      env:
         INPUT_PLATFORMS: ${{ inputs.platforms }}
       run: |
         SKAFFOLD_PLATFORM="$(printf '%s' "$INPUT_PLATFORMS" | jq -r 'join(",")')"
         echo "platform=$SKAFFOLD_PLATFORM" >> "$GITHUB_OUTPUT"
       shell: bash
     - env:
-        SKAFFOLD_PLATFORM: ${{ steps.skaffold.outputs.platform }}
+        SKAFFOLD_PLATFORM: ${{ steps.platform.outputs.platform }}
         SKAFFOLD_PROFILE: ${{ inputs.profile }}
       id: skaffold
       run: |
         skaffold config set --global collect-metrics false
-        skaffold build "${args[@]}"
-        MANIFEST="$(skaffold render "${args[@]}")"
+        skaffold build
+        MANIFEST="$(skaffold render)"
         {
           echo 'manifest<<EOF'
           echo "$MANIFEST"


### PR DESCRIPTION
Fix two bugs in the Skaffold integration action:

1. The step that sets the `platform` output via `$GITHUB_OUTPUT` was missing an `id:`, so `steps.skaffold.outputs.platform` could never resolve — the `SKAFFOLD_PLATFORM` env var was always empty in the build step.
2. `${args[@]}` was referenced but never initialized, causing `skaffold build` and `skaffold render` to receive a literal empty string argument.

This is the first in a stack of action fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #218
* #217
* #216
* __->__ #215