### PR TITLE
Use GH_TOKEN instead of GITHUB_TOKEN in update action

### DIFF
--- a/update/action.yaml
+++ b/update/action.yaml
@@ -46,7 +46,7 @@ runs:
       run: nix run "$INPUT_REGISTRY#ghstack" -- submit
       shell: bash
     - env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
         INPUT_REGISTRY: ${{ inputs.registry }}
       if: inputs.method == 'sapling-pull-request'
       run: nix run "$INPUT_REGISTRY#sapling" -- pr submit


### PR DESCRIPTION
Standardize on `GH_TOKEN` in the update action's environment.

The sapling-pull-request step was using `GITHUB_TOKEN` while every other action in this repo uses `GH_TOKEN` for GitHub CLI authentication. This aligns with the convention.

This is the second in a stack of action fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #218
* #217
* __->__ #216
* #215