### PR TITLE
Remove unsupported pull-request-url from cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: shikanime-studio/actions/cleanup@v9
         with:
           github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
-          pull-request-url: ${{ github.event.pull_request.html_url }}
 name: Cleanup
 'on':
   pull_request:


### PR DESCRIPTION
Remove the `pull-request-url` input from the cleanup workflow.

The cleanup action only accepts `github-token` and `head-ref` inputs. The `pull-request-url` input was silently ignored by the action, so this removes the misleading parameter from the workflow.

This is the third in a stack of action fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #218
* __->__ #217
* #216
* #215