### PR TITLE
Update action version references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ jobs:
           github_access_token: >-
             ${{ steps.createGithubAppToken.outputs.token
                 || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/update@v7
+      - uses: shikanime-studio/actions/update@v9
         with:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -395,5 +395,5 @@ jobs:
           token: >-
             ${{ steps.createGithubAppToken.outputs.token
                 || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/cleanup@v7
+      - uses: shikanime-studio/actions/cleanup@v9
 ```


### PR DESCRIPTION
Update action version references in README from `@v7` to `@v9`.

The README examples referenced outdated versions for the `cleanup` and `update` actions. Updated to match the currently published versions.

This is the fourth in a stack of action fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #218
* #217
* #216
* #215