### PR TITLE
Fix skaffold step id and undefined args

### DIFF
--- a/skaffold/integration/action.yaml
+++ b/skaffold/integration/action.yaml
@@ -15,20 +15,21 @@ outputs:
 runs:
   using: composite
   steps:
-    - env:
+    - id: platform
+      env:
         INPUT_PLATFORMS: ${{ inputs.platforms }}
       run: |
         SKAFFOLD_PLATFORM="$(printf '%s' "$INPUT_PLATFORMS" | jq -r 'join(",")')"
         echo "platform=$SKAFFOLD_PLATFORM" >> "$GITHUB_OUTPUT"
       shell: bash
     - env:
-        SKAFFOLD_PLATFORM: ${{ steps.skaffold.outputs.platform }}
+        SKAFFOLD_PLATFORM: ${{ steps.platform.outputs.platform }}
         SKAFFOLD_PROFILE: ${{ inputs.profile }}
       id: skaffold
       run: |
         skaffold config set --global collect-metrics false
-        skaffold build "${args[@]}"
-        MANIFEST="$(skaffold render "${args[@]}")"
+        skaffold build
+        MANIFEST="$(skaffold render)"
         {
           echo 'manifest<<EOF'
           echo "$MANIFEST"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #222
* #221
* #220
* __->__ #219

Add the missing 'platform' step id to the skaffold integration action
output step. Remove the undefined '${args[]}' reference that would
cause a runtime error.