### PR TITLE
Use GH_TOKEN instead of GITHUB_TOKEN in update action

### DIFF
--- a/update/action.yaml
+++ b/update/action.yaml
@@ -46,7 +46,7 @@ runs:
       run: nix run "$INPUT_REGISTRY#ghstack" -- submit
       shell: bash
     - env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
         INPUT_REGISTRY: ${{ inputs.registry }}
       if: inputs.method == 'sapling-pull-request'
       run: nix run "$INPUT_REGISTRY#sapling" -- pr submit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #222
* #221
* __->__ #220
* #219

The update action referenced \${GITHUB_TOKEN} but the workflow passes
the token as GH_TOKEN. Update the env var reference to match.