### PR TITLE
Remove unsupported pull-request-url from cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: shikanime-studio/actions/cleanup@v9
         with:
           github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
-          pull-request-url: ${{ github.event.pull_request.html_url }}
 name: Cleanup
 'on':
   pull_request:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #222
* __->__ #221
* #220
* #219

The cleanup workflow used a 'pull-request-url' input that is not
supported by the GitHub Actions 'pull_request' trigger. Remove the
unsupported input to prevent workflow errors.