### PR TITLE
Fix README examples, replace jj with git in backport/update, add git identity to land

### DIFF
--- a/.github/workflows/commands.yaml
+++ b/.github/workflows/commands.yaml
@@ -139,5 +139,6 @@ name: Commands
   issue_comment:
     types:
       - created
+  workflow_dispatch:
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,27 @@ This repository provides comment-driven agents (composite actions) that automate
 - `.backport` — Backports the current PR onto a target branch. Usage: `.backport | <target-branch>`
 - `.run` — Triggers a workflow dispatch. Usage: `.run | <workflow-name-or-path>`
 
+## Workflow Triggers
+
+- Comment commands are triggered by `issue_comment` on PRs
+- `workflow_dispatch` is enabled on the Commands workflow for manual testing
+- Release workflow supports `workflow_dispatch` for manual releases
+
 ## Nix Utilities
 
 - `nix/setup` — Installs Nix and configures Cachix (optionally with QEMU)
 - `nix/setup-checks-jobs` — Produces a matrix of `{ system, runner }` for checks
 - `nix/setup-packages-jobs` — Produces a matrix of `{ system, runner, name }` for package builds
+
+## Backport Strategy
+
+- `ghstack` method: unlinks the stack, rebases onto target, resubmits
+- `sapling` method: uses sapling pr unlink/rebase/submit
+- `github-pull-request` method: uses plain git cherry-pick (no jj dependency). Creates a `backport/<target>/<head>` branch and opens a PR
+
+## Update Strategy
+
+- `ghstack`/`sapling` methods: use respective tools for submission
+- `github-pull-request` method: uses plain git (no jj dependency). Creates a timestamped `update/flake-<datetime>` branch and opens a PR. Skips if no changes.
 
 *Licensed under Apache-2.0. Test actions locally with `act` before submitting. Update README when adding new actions*

--- a/README.md
+++ b/README.md
@@ -53,18 +53,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/land@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/land@v9
         with:
           email: operator6o@shikanime.studio
           fullname: Operator 6O
@@ -90,18 +82,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/rebase@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/rebase@v9
         with:
           email: operator6o@shikanime.studio
           fullname: Operator 6O
@@ -127,18 +111,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/close@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/close@v9
         with:
           github-token: >-
             ${{ steps.createGithubAppToken.outputs.token
@@ -159,18 +135,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/backport@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/backport@v9
         with:
           github-token: >-
             ${{ steps.createGithubAppToken.outputs.token
@@ -190,7 +158,7 @@ Linux) enable QEMU for additional platforms.
 
 ```yaml
 steps:
-  - uses: shikanime-studio/actions/nix/setup@main
+  - uses: shikanime-studio/actions/nix/setup@v9
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       cachix-name: my-cache
@@ -332,17 +300,9 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
       - uses: shikanime-studio/actions/update@v9
         with:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -389,11 +349,8 @@ jobs:
           client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
       - uses: shikanime-studio/actions/cleanup@v9
 ```

--- a/backport/action.yaml
+++ b/backport/action.yaml
@@ -48,42 +48,33 @@ runs:
           --dest "$INPUT_TARGET_BRANCH"
         nix run "$INPUT_REGISTRY#sapling" -- pr submit
       shell: bash
-    - continue-on-error: true
-      env:
-        INPUT_REGISTRY: ${{ inputs.registry }}
-      if: inputs.method == 'github-pull-request'
-      run: |
-        nix run "$INPUT_REGISTRY#jujutsu" -- git init
-      shell: bash
     - env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_PULL_REQUEST_URL: ${{ inputs.pull-request-url }}
-        INPUT_REGISTRY: ${{ inputs.registry }}
         INPUT_TARGET_BRANCH: ${{ inputs.target-branch }}
         INPUT_USERNAME: ${{ inputs.username }}
       if: inputs.method == 'github-pull-request'
       run: |
-        nix run "$INPUT_REGISTRY#jujutsu" -- git fetch --remote origin
-        nix run "$INPUT_REGISTRY#jujutsu" -- config set \
-          --repo templates.git_push_bookmark \
-          "\"$INPUT_USERNAME/push-\" ++ change_id.short()"
-        nix run "$INPUT_REGISTRY#jujutsu" -- new "$INPUT_TARGET_BRANCH@origin"
-        nix run "$INPUT_REGISTRY#jujutsu" -- rebase \
-          -b @ \
-          -o "$INPUT_PULL_REQUEST_URL"
-        nix run "$INPUT_REGISTRY#jujutsu" -- git push --change @
-
-        PUSH_BRANCH=$(nix run "$INPUT_REGISTRY#jujutsu" -- log \
-          --limit 1 \
-          --template "{{bookmarks}}" \
-          @)
-
         ORIG_TITLE=$(gh pr view "$INPUT_PULL_REQUEST_URL" --json title -q .title)
-        ORIG_BODY_FILE=<(gh pr view "$INPUT_PULL_REQUEST_URL" --json body -q .body)
+        ORIG_BODY=$(gh pr view "$INPUT_PULL_REQUEST_URL" --json body -q .body)
+        ORIG_HEAD=$(gh pr view "$INPUT_PULL_REQUEST_URL" --json headRefName -q .headRefName)
+
+        git fetch origin "$INPUT_TARGET_BRANCH" "$ORIG_HEAD"
+
+        BACKPORT_BRANCH="backport/${INPUT_TARGET_BRANCH}/${ORIG_HEAD}"
+        git checkout -b "$BACKPORT_BRANCH" "origin/$INPUT_TARGET_BRANCH"
+
+        if ! git cherry-pick "origin/$ORIG_HEAD"; then
+          echo "Cherry-pick failed. Manual resolution required."
+          git cherry-pick --abort
+          exit 1
+        fi
+
+        git push origin "$BACKPORT_BRANCH"
 
         gh pr create \
-          --head "$PUSH_BRANCH" \
+          --head "$BACKPORT_BRANCH" \
           --base "$INPUT_TARGET_BRANCH" \
           --title "$ORIG_TITLE" \
-          --body-file "$ORIG_BODY_FILE"
+          --body "$ORIG_BODY"
       shell: bash

--- a/land/action.yaml
+++ b/land/action.yaml
@@ -5,6 +5,14 @@ inputs:
     default: main
     description: The base branch to rebase onto
     required: false
+  email:
+    default: ${{ github.actor }}@users.noreply.github.com
+    description: Git user email for commits
+    required: false
+  fullname:
+    default: ${{ github.actor }}
+    description: Git user name for commits
+    required: false
   method:
     default: github-pull-request
     description: One of 'ghstack', 'sapling-pull-request', or 'github-pull-request' (required when invoking this action directly)
@@ -25,10 +33,14 @@ runs:
   using: composite
   steps:
     - env:
+        GH_TOKEN: ${{ inputs.github-token }}
         INPUT_PULL_REQUEST_URL: ${{ inputs.pull-request-url }}
         INPUT_REGISTRY: ${{ inputs.registry }}
       if: inputs.method == 'ghstack'
-      run: nix run "$INPUT_REGISTRY#ghstack" -- land "$INPUT_PULL_REQUEST_URL"
+      run: |
+        git config user.email "${{ inputs.email }}"
+        git config user.name "${{ inputs.fullname }}"
+        nix run "$INPUT_REGISTRY#ghstack" -- land "$INPUT_PULL_REQUEST_URL"
       shell: bash
     - env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/update/action.yaml
+++ b/update/action.yaml
@@ -51,33 +51,29 @@ runs:
       if: inputs.method == 'sapling-pull-request'
       run: nix run "$INPUT_REGISTRY#sapling" -- pr submit
       shell: bash
-    - continue-on-error: true
-      env:
-        INPUT_REGISTRY: ${{ inputs.registry }}
-      if: inputs.method == 'github-pull-request'
-      run: nix run "$INPUT_REGISTRY#jujutsu" -- git init
-      shell: bash
     - env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_BASE: ${{ inputs.base }}
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
-        INPUT_REGISTRY: ${{ inputs.registry }}
         INPUT_USERNAME: ${{ inputs.username }}
       if: inputs.method == 'github-pull-request'
       run: |
-        nix run "$INPUT_REGISTRY#jujutsu" -- git fetch --remote origin
-        nix run "$INPUT_REGISTRY#jujutsu" -- config set \
-          --repo templates.git_push_bookmark \
-          "\"$INPUT_USERNAME/push-\" ++ change_id.short()"
-        nix run "$INPUT_REGISTRY#jujutsu" -- git push --change @
+        git add flake.lock
+        if git diff --cached --quiet; then
+          echo "No changes to commit."
+          exit 0
+        fi
 
-        PUSH_BRANCH=$(nix run "$INPUT_REGISTRY#jujutsu" -- log \
-          --limit 1 \
-          --template "{{bookmarks}}" \
-          @)
+        git config user.email "${INPUT_USERNAME}@users.noreply.github.com"
+        git config user.name "$INPUT_USERNAME"
+
+        UPDATE_BRANCH="update/flake-$(date +%Y%m%d-%H%M%S)"
+        git checkout -b "$UPDATE_BRANCH"
+        git commit -m "$INPUT_COMMIT_MESSAGE"
+        git push origin "$UPDATE_BRANCH"
 
         EXISTING=$(gh pr list \
-          --head "$PUSH_BRANCH" \
+          --head "$UPDATE_BRANCH" \
           --base "$INPUT_BASE" \
           --state open \
           --json number \
@@ -85,11 +81,11 @@ runs:
 
         if [ -z "$EXISTING" ]; then
           gh pr create \
-            --head "$PUSH_BRANCH" \
+            --head "$UPDATE_BRANCH" \
             --base "$INPUT_BASE" \
             --title "$INPUT_COMMIT_MESSAGE" \
             --body "Automated flake update."
         else
-          echo "Existing open PR #$EXISTING for $PUSH_BRANCH -> $INPUT_BASE, not creating a new one."
+          echo "Existing open PR #$EXISTING for $UPDATE_BRANCH -> $INPUT_BASE, not creating a new one."
         fi
       shell: bash


### PR DESCRIPTION
## Summary

Multiple improvements to increase action reliability and reduce dependencies.

### Changes

1. **README examples updated** — Replaced `actions/checkout@v6` + `cachix/install-nix-action@v31` with `shikanime-studio/actions/nix/setup@v9` in all examples. Updated all action references from `@main` to `@v9`.

2. **Backport: replace jj with git** — The `github-pull-request` method now uses plain `git cherry-pick` instead of jujutsu. Creates a `backport/<target>/<head>` branch and opens a PR. Removes the `nixpkgs#jujutsu` dependency for this code path.

3. **Update: replace jj with git** — The `github-pull-request` method now uses plain git commit/push instead of jujutsu. Creates a timestamped `update/flake-<datetime>` branch. Skips if no changes. Removes the `nixpkgs#jujutsu` dependency.

4. **Land: add git identity** — Added `git config user.email/user.name` before `ghstack land` in CI. New `email` and `fullname` inputs (default to `github.actor`).

5. **Commands workflow: add workflow_dispatch** — Enables manual triggering for testing without creating fake PR comments.

6. **AGENTS.md updated** — Documents new backport/update strategy and workflow triggers.

### Why

- jj dependency in backport/update was heavy and could fail if nixpkgs pin lacked jj or remote origin was misconfigured
- README examples were inconsistent with the repo's own workflow patterns
- Land action failed in CI because git identity was not set before ghstack operations