### PR TITLE
Fix README examples: use nix/setup@v9 and consistent action versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ name: Command
   issue_comment:
     types:
       - created
+  workflow_dispatch:
 permissions:
   contents: write
   issues: write
@@ -53,18 +54,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/land@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/land@v9
         with:
           email: operator6o@shikanime.studio
           fullname: Operator 6O
@@ -90,18 +83,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/rebase@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/rebase@v9
         with:
           email: operator6o@shikanime.studio
           fullname: Operator 6O
@@ -127,18 +112,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/close@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/close@v9
         with:
           github-token: >-
             ${{ steps.createGithubAppToken.outputs.token
@@ -159,18 +136,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: shikanime-studio/actions/command/backport@main
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/backport@v9
         with:
           github-token: >-
             ${{ steps.createGithubAppToken.outputs.token
@@ -190,7 +159,7 @@ Linux) enable QEMU for additional platforms.
 
 ```yaml
 steps:
-  - uses: shikanime-studio/actions/nix/setup@main
+  - uses: shikanime-studio/actions/nix/setup@v9
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       cachix-name: my-cache
@@ -303,7 +272,10 @@ Example job:
           permission-issues: write
           permission-pull-requests: read
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: shikanime-studio/actions/command/run@main
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: shikanime-studio/actions/command/run@v9
         with:
           github-token: >-
             ${{ steps.createGithubAppToken.outputs.token
@@ -332,17 +304,9 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
-      - uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
       - uses: shikanime-studio/actions/update@v9
         with:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -389,11 +353,8 @@ jobs:
           client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: shikanime-studio/actions/nix/setup@v9
         with:
-          fetch-depth: 0
-          token: >-
-            ${{ steps.createGithubAppToken.outputs.token
-                || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
       - uses: shikanime-studio/actions/cleanup@v9
 ```


### PR DESCRIPTION
## Summary

Replaces actions/checkout@v6 + cachix/install-nix-action@v31 with
shikanime-studio/actions/nix/setup@v9 in all consumer-facing examples.
Updates all action references from @main to @v9.

## Why

README examples should match the repo's own workflow patterns. The old
examples used upstream actions that the repo has replaced with its own
shimmed versions.

Part of a stack of improvements:
- PR #225: Replace jj with git in backport action
- PR #226: Replace jj with git in update action
- PR #227: Add git identity to land action
- PR #228: Add workflow_dispatch to commands workflow