### PR TITLE
Improve error handling in matrix and checks actions

### DIFF
--- a/checks/action.yaml
+++ b/checks/action.yaml
@@ -26,46 +26,57 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const requiredLabel = core.getInput('label') || 'auto';
-          const prUrl = core.getInput('pull-request-url', { required: true });
-          const prNumber = Number(prUrl.split('/pull/')[1]?.split(/[\/#?]/)[0]);
-          if (!prNumber) {
-            core.setOutput('continue', 'false');
-            return;
-          }
-          const headSha = context.payload?.check_suite?.head_sha;
-          const { owner, repo } = context.repo;
-          const query = `
-            query($owner: String!, $name: String!, $number: Int!) {
-              repository(owner: $owner, name: $name) {
-                pullRequest(number: $number) {
-                  state
-                  isDraft
-                  merged
-                  headRefOid
-                  labels(first: 100) {
-                    nodes { name }
-                  }
-                  commits(last: 1) {
-                    nodes {
-                      commit {
-                        statusCheckRollup { state }
+          try {
+            const requiredLabel = core.getInput('label') || 'auto';
+            const prUrl = core.getInput('pull-request-url', { required: true });
+            const prNumber = Number(prUrl.split('/pull/')[1]?.split(/[\/#?]/)[0]);
+            if (!prNumber || isNaN(prNumber)) {
+              core.warning(`Invalid PR URL: ${prUrl}`);
+              core.setOutput('continue', 'false');
+              return;
+            }
+            const headSha = context.payload?.check_suite?.head_sha;
+            const { owner, repo } = context.repo;
+            const query = `
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    state
+                    isDraft
+                    merged
+                    headRefOid
+                    labels(first: 100) {
+                      nodes { name }
+                    }
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup { state }
+                        }
                       }
                     }
                   }
                 }
               }
+            `;
+            const resp = await github.graphql(query, { owner, name: repo, number: prNumber });
+            const pr = resp.repository.pullRequest;
+            if (!pr) {
+              core.warning(`PR #${prNumber} not found`);
+              core.setOutput('continue', 'false');
+              return;
             }
-          `;
-          const resp = await github.graphql(query, { owner, name: repo, number: prNumber });
-          const pr = resp.repository.pullRequest;
-          const prHead = pr.headRefOid;
-          const labels = (pr.labels?.nodes || []).map((l) => l.name);
-          const labelOk = labels.includes(requiredLabel);
-          const nodes = pr.commits.nodes;
-          const rollupState = nodes?.[0]?.commit?.statusCheckRollup?.state || '';
-          const shaOk = headSha ? prHead === headSha : true;
-          const prOk = pr.state === 'OPEN' && pr.isDraft === false && pr.merged === false;
-          const checksOk = rollupState === 'SUCCESS';
-          const ok = prOk && labelOk && checksOk && shaOk;
-          core.setOutput('continue', ok ? 'true' : 'false');
+            const prHead = pr.headRefOid;
+            const labels = (pr.labels?.nodes || []).map((l) => l.name);
+            const labelOk = labels.includes(requiredLabel);
+            const nodes = pr.commits.nodes;
+            const rollupState = nodes?.[0]?.commit?.statusCheckRollup?.state || '';
+            const shaOk = headSha ? prHead === headSha : true;
+            const prOk = pr.state === 'OPEN' && pr.isDraft === false && pr.merged === false;
+            const checksOk = rollupState === 'SUCCESS';
+            const ok = prOk && labelOk && checksOk && shaOk;
+            core.setOutput('continue', ok ? 'true' : 'false');
+          } catch (err) {
+            core.warning(`Checks failed: ${err.message}`);
+            core.setOutput('continue', 'false');
+          }

--- a/nix/setup-checks-jobs/action.yaml
+++ b/nix/setup-checks-jobs/action.yaml
@@ -21,25 +21,37 @@ runs:
   steps:
     - id: matrix
       run: |
-        JSON="$(nix flake show --json --all-systems --accept-flake-config --no-pure-eval)"
-        MATRIX="$(
-          jq -c '
-            .checks as $root
-            | ($root | keys) as $available
-            | (env.INPUT_SYSTEMS | fromjson) as $systems
-            | ($systems | to_entries)
-            | map(. as $pair
-                  | ($pair.value
-                     | map(select(. as $s | $available | index($s)))
-                     | map({system: ., runner: $pair.key})
-                    )
-                )
-            | flatten
-          ' <<< "$JSON"
-        )"
+        MATRIX="[]"
+        CONTINUE="false"
+
+        if ! JSON="$(nix flake show --json --all-systems --accept-flake-config --no-pure-eval 2>/dev/null)"; then
+          echo "::warning::nix flake show failed, skipping checks matrix"
+        elif [ -z "$JSON" ] || [ "$JSON" = "null" ]; then
+          echo "::warning::nix flake show returned empty output"
+        else
+          RESULT="$(
+            jq -c '
+              .checks as $root
+              | ($root | keys) as $available
+              | (env.INPUT_SYSTEMS | fromjson) as $systems
+              | ($systems | to_entries)
+              | map(. as $pair
+                    | ($pair.value
+                       | map(select(. as $s | $available | index($s)))
+                       | map({system: ., runner: $pair.key})
+                      )
+                  )
+              | flatten
+            ' <<< "$JSON" 2>/dev/null
+          )"
+          if [ -n "$RESULT" ] && [ "$RESULT" != "null" ]; then
+            MATRIX="$RESULT"
+            CONTINUE=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
+          fi
+        fi
+
         echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-        continue=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
-        echo "continue=$continue" >> "$GITHUB_OUTPUT"
+        echo "continue=$CONTINUE" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
         INPUT_SYSTEMS: ${{ inputs.systems }}

--- a/nix/setup-packages-jobs/action.yaml
+++ b/nix/setup-packages-jobs/action.yaml
@@ -25,33 +25,45 @@ runs:
   steps:
     - id: matrix
       run: |
-        JSON="$(nix flake show --json --all-systems --accept-flake-config --no-pure-eval)"
-        MATRIX="$(
-          jq -c '
-            .packages
-            | to_entries
-            | (env.INPUT_SYSTEMS | fromjson) as $systems
-            | ($systems | to_entries) as $pairs
-            | ($pairs
-               | reduce .[] as $p ({}; . + ($p.value | reduce .[] as $s ({}; . + {($s): $p.key})))
-              ) as $sys2runner
-            | map(select(.key as $s | $sys2runner | has($s)))
-            | reduce .[] as $entry ([]; . += (
-                  ( ($entry.value | keys)
-                    | (env.INPUT_EXCLUDES | fromjson) as $excludes
-                    | map(select(. as $name | $excludes | index($name) | not))
-                  )
-                  | map({
-                      system: $entry.key,
-                      runner: ($sys2runner[$entry.key] // "ubuntu-latest"),
-                      name: .
-                    })
-                ))
-          ' <<< "$JSON"
-        )"
+        MATRIX="[]"
+        CONTINUE="false"
+
+        if ! JSON="$(nix flake show --json --all-systems --accept-flake-config --no-pure-eval 2>/dev/null)"; then
+          echo "::warning::nix flake show failed, skipping packages matrix"
+        elif [ -z "$JSON" ] || [ "$JSON" = "null" ]; then
+          echo "::warning::nix flake show returned empty output"
+        else
+          RESULT="$(
+            jq -c '
+              .packages
+              | to_entries
+              | (env.INPUT_SYSTEMS | fromjson) as $systems
+              | ($systems | to_entries) as $pairs
+              | ($pairs
+                 | reduce .[] as $p ({}; . + ($p.value | reduce .[] as $s ({}; . + {($s): $p.key})))
+                ) as $sys2runner
+              | map(select(.key as $s | $sys2runner | has($s)))
+              | reduce .[] as $entry ([]; . += (
+                    ( ($entry.value | keys)
+                      | (env.INPUT_EXCLUDES | fromjson) as $excludes
+                      | map(select(. as $name | $excludes | index($name) | not))
+                    )
+                    | map({
+                        system: $entry.key,
+                        runner: ($sys2runner[$entry.key] // "ubuntu-latest"),
+                        name: .
+                      })
+                  ))
+            ' <<< "$JSON" 2>/dev/null
+          )"
+          if [ -n "$RESULT" ] && [ "$RESULT" != "null" ]; then
+            MATRIX="$RESULT"
+            CONTINUE=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
+          fi
+        fi
+
         echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-        continue=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
-        echo "continue=$continue" >> "$GITHUB_OUTPUT"
+        echo "continue=$CONTINUE" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
         INPUT_EXCLUDES: ${{ inputs.excludes }}

--- a/nix/setup/action.yaml
+++ b/nix/setup/action.yaml
@@ -70,7 +70,7 @@ runs:
           ${{ steps.extra-platforms-config.outputs.nix-config }}
           ${{ inputs.extra-config }}
         github_access_token: ${{ inputs.github-token }}
-    - if: ${{ inputs.cachix-name != '' }}
+    - if: ${{ inputs.cachix-name != '' && inputs.cachix-auth-token != '' }}
       uses: cachix/cachix-action@v17
       with:
         name: ${{ inputs.cachix-name }}

--- a/skaffold/setup-profiles-jobs/action.yaml
+++ b/skaffold/setup-profiles-jobs/action.yaml
@@ -18,14 +18,21 @@ runs:
     - id: matrix
       run: |
         FILE="$INPUT_PATH/skaffold.yaml"
+        MATRIX="[]"
+        CONTINUE="false"
+
         if [ ! -f "$FILE" ]; then
-          echo "::error::skaffold.yaml not found at: $FILE"
-          exit 1
+          echo "::warning::skaffold.yaml not found at: $FILE"
+        else
+          RESULT="$(yq -o=json -I=0 '.profiles // [] | map({"name": .name})' "$FILE" 2>/dev/null)"
+          if [ -n "$RESULT" ] && [ "$RESULT" != "null" ]; then
+            MATRIX="$RESULT"
+          fi
         fi
-        MATRIX="$(yq -o=json -I=0 '.profiles // [] | map({"name": .name})' "$FILE")"
+
+        CONTINUE=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
         echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-        continue=$([ "$MATRIX" = "[]" ] && echo "false" || echo "true")
-        echo "continue=$continue" >> "$GITHUB_OUTPUT"
+        echo "continue=$CONTINUE" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #239

----

- setup-checks-jobs: handle nix flake show failure gracefully
- setup-packages-jobs: same defensive pattern for packages
- setup-profiles-jobs: warn instead of error on missing skaffold.yaml
- checks: wrap github-script in try/catch, validate PR response

Prevents fromJSON('') JToken parse errors when upstream commands fail.

Signed-off-by: william.phetsinorath@shikanime.studio