### PR TITLE
Fix cleanup action: pass pull-request-url to detect ghstack branches

### DIFF
--- a/cleanup/action.yaml
+++ b/cleanup/action.yaml
@@ -9,6 +9,10 @@ inputs:
     default: ${{ github.head_ref }}
     description: The head branch to delete
     required: false
+  pull-request-url:
+    default: ""
+    description: The Pull Request URL (for ghstack/sapling branch detection)
+    required: false
 runs:
   using: composite
   steps:
@@ -16,6 +20,7 @@ runs:
       uses: shikanime-studio/actions/checkout@v9
       with:
         github-token: ${{ inputs.github-token }}
+        pull-request-url: ${{ inputs.pull-request-url }}
     - env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_HEAD_REF: ${{ inputs.head-ref }}


### PR DESCRIPTION
## Problem

The `cleanup/action.yaml` did not declare `pull-request-url` as an input.
When workflows passed this input, it was silently dropped with:
`Unexpected input(s) 'pull-request-url', valid inputs are ['github-token', 'head-ref']`

The checkout step inside the action never received the PR URL, so it
defaulted to `method=github-pull-request`. For ghstack PRs, only the
`head` branch was deleted — `base` and `orig` branches were left
dangling.

## Fix

- Added `pull-request-url` input to `cleanup/action.yaml`
- Pass it through to the `checkout` step so ghstack branch detection works

## Impact

15 repos already pass `pull-request-url` in their cleanup workflows and
will benefit immediately. Repos with custom cleanup logic (automata,
minishells, tailscale-gateway, x-shikanime/algorithm) already handle
ghstack correctly.