### PR TITLE
Add pull-request-url input to cleanup action

### DIFF
--- a/cleanup/action.yaml
+++ b/cleanup/action.yaml
@@ -9,6 +9,10 @@ inputs:
     default: ${{ github.head_ref }}
     description: The head branch to delete
     required: false
+  pull-request-url:
+    default: ""
+    description: The Pull Request URL (for ghstack/sapling branch detection)
+    required: false
 runs:
   using: composite
   steps:
@@ -16,6 +20,7 @@ runs:
       uses: shikanime-studio/actions/checkout@v9
       with:
         github-token: ${{ inputs.github-token }}
+        pull-request-url: ${{ inputs.pull-request-url }}
     - env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_HEAD_REF: ${{ inputs.head-ref }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #241

The cleanup action was silently dropping the pull-request-url input from
workflows because it was not declared. This prevented the checkout step
from detecting ghstack branches, so only the head branch was deleted
and base/orig branches were left dangling.