### PR TITLE
Add push input to skaffold integration action

### DIFF
--- a/skaffold/integration/action.yaml
+++ b/skaffold/integration/action.yaml
@@ -8,6 +8,10 @@ inputs:
     default: '["linux/amd64","linux/arm64"]'
     description: JSON array of target platforms
     required: false
+  push:
+    default: "true"
+    description: Whether to push images during build
+    required: false
 outputs:
   manifest:
     description: Rendered manifest YAML
@@ -36,3 +40,4 @@ runs:
       env:
         SKAFFOLD_PLATFORM: ${{ steps.platform.outputs.platform }}
         SKAFFOLD_PROFILE: ${{ inputs.profile }}
+        SKAFFOLD_PUSH: ${{ inputs.push }}


### PR DESCRIPTION
## Design

New composite action input (`push`, default `true`) sets `SKAFFOLD_PUSH` env var during `skaffold build`. Callers can disable push for PR-triggered workflows without changing skaffold config.

## Changes

- `skaffold/integration/action.yaml`: Added `push` input (boolean, default true), forwarded as `SKAFFOLD_PUSH` env var to `skaffold build` step.

## Usage

```yaml
- uses: shikanime-studio/actions/skaffold/integration@v9
  with:
    push: false  # equivalent to SKAFFOLD_PUSH=false
```

Related: shikanime-studio/devlib#000